### PR TITLE
Add python version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,6 @@ setup(name="reacting_rl_envs",
       url="https://github.com/lychanl/reacting-rl-envs",
       keywords=["reinforcement learning", "reinforcement learning environmnts"],
       packages=find_packages(),
+      python_requires='<3.9',
       install_requires=["numpy", "gym", "Box2D"]
 )


### PR DESCRIPTION
Currently Box2D==2.3.10 (newest) requires at most python 3.8. Older versions of Box2D (eg. 2..3.2 which is newst for python newer than 3.8) require additional packages to run without errors on multiple platforms.